### PR TITLE
chore: cleanup deprecated constructor for base plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    implementation platform('run.halo.tools.platform:plugin:2.7.0-SNAPSHOT')
+    implementation platform('run.halo.tools.platform:plugin:2.10.0-SNAPSHOT')
     compileOnly 'run.halo.app:api'
 
     testImplementation 'run.halo.app:api'

--- a/src/main/java/run/halo/katex/KatexPlugin.java
+++ b/src/main/java/run/halo/katex/KatexPlugin.java
@@ -1,21 +1,14 @@
 package run.halo.katex;
 
-import org.pf4j.PluginWrapper;
 import org.springframework.stereotype.Component;
+
 import run.halo.app.plugin.BasePlugin;
+import run.halo.app.plugin.PluginContext;
 
 @Component
 public class KatexPlugin extends BasePlugin {
 
-    public KatexPlugin(PluginWrapper wrapper) {
-        super(wrapper);
-    }
-
-    @Override
-    public void start() {
-    }
-
-    @Override
-    public void stop() {
+    public KatexPlugin(PluginContext context) {
+        super(context);
     }
 }

--- a/src/main/resources/plugin.yaml
+++ b/src/main/resources/plugin.yaml
@@ -4,7 +4,7 @@ metadata:
   name: plugin-katex
 spec:
   enabled: true
-  requires: ">=2.7.0"
+  requires: ">=2.10.0"
   author:
     name: Halo OSS Team
     website: https://github.com/halo-dev


### PR DESCRIPTION
### What this PR does?
移除对已过时的 PluginWrapper 的引用

see also https://github.com/halo-dev/halo/pull/6243

```release-note
None
```