### PR TITLE
Enhance PJAX compatibility

### DIFF
--- a/src/main/java/run/halo/katex/DefaultPostContentHandler.java
+++ b/src/main/java/run/halo/katex/DefaultPostContentHandler.java
@@ -19,7 +19,7 @@ public class DefaultPostContentHandler implements ReactivePostContentHandler {
         String display_selector) {
         String parsedKatexScript =
             KaTeXJSInjector.getParsedKatexScript(inline_selector, display_selector);
-        contentContext.setContent(parsedKatexScript + "\n" + contentContext.getContent());
+        contentContext.setContent(contentContext.getContent() + "\n" + parsedKatexScript);
     }
 
     @Override

--- a/src/main/java/run/halo/katex/DefaultSinglePageContentHandler.java
+++ b/src/main/java/run/halo/katex/DefaultSinglePageContentHandler.java
@@ -19,7 +19,7 @@ public class DefaultSinglePageContentHandler implements ReactiveSinglePageConten
         String display_selector) {
         String parsedKatexScript =
             KaTeXJSInjector.getParsedKatexScript(inline_selector, display_selector);
-        contentContext.setContent(parsedKatexScript + "\n" + contentContext.getContent());
+        contentContext.setContent(contentContext.getContent() + "\n" + parsedKatexScript);
     }
 
     @Override

--- a/src/main/java/run/halo/katex/KaTeXHeadProcessor.java
+++ b/src/main/java/run/halo/katex/KaTeXHeadProcessor.java
@@ -1,0 +1,43 @@
+package run.halo.katex;
+
+import java.util.Properties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.PropertyPlaceholderHelper;
+import org.thymeleaf.context.ITemplateContext;
+import org.thymeleaf.model.IModel;
+import org.thymeleaf.model.IModelFactory;
+import org.thymeleaf.processor.element.IElementModelStructureHandler;
+import reactor.core.publisher.Mono;
+import run.halo.app.plugin.PluginContext;
+import run.halo.app.theme.dialect.TemplateHeadProcessor;
+
+@Component
+@RequiredArgsConstructor
+public class KaTeXHeadProcessor implements TemplateHeadProcessor {
+
+    static final PropertyPlaceholderHelper PROPERTY_PLACEHOLDER_HELPER = new PropertyPlaceholderHelper("${", "}");
+
+    private final PluginContext pluginContext;
+
+    @Override
+    public Mono<Void> process(ITemplateContext context, IModel model,
+        IElementModelStructureHandler structureHandler) {
+        final IModelFactory modelFactory = context.getModelFactory();
+        model.add(modelFactory.createText(getHeadTags()));
+        return Mono.empty();
+    }
+
+    private String getHeadTags() {
+
+        final Properties properties = new Properties();
+        properties.setProperty("version", pluginContext.getVersion());
+
+        return PROPERTY_PLACEHOLDER_HELPER.replacePlaceholders("""
+            <!-- plugin-katex start -->
+            <script src="/plugins/plugin-katex/assets/static/katex.min.js?version=${version}"></script>
+            <link rel="stylesheet" href="/plugins/plugin-katex/assets/static/katex.min.css?version=${version}" />
+            <!-- plugin-katex end -->
+            """, properties);
+    }
+}

--- a/src/main/java/run/halo/katex/KaTeXJSInjector.java
+++ b/src/main/java/run/halo/katex/KaTeXJSInjector.java
@@ -3,22 +3,15 @@ package run.halo.katex;
 public class KaTeXJSInjector {
     static String getParsedKatexScript(String inline_selector, String display_selector) {
         String katexScript = """
-            <link rel="stylesheet" href="/plugins/plugin-katex/assets/static/katex.min.css">
-            <script defer src="/plugins/plugin-katex/assets/static/katex.min.js"></script>
-            <script>
-                document.addEventListener("DOMContentLoaded", function() {
-                  const postBody = document.body
-                  const renderMath = (selector,displayMode) => {
-                    const els = postBody.querySelectorAll(selector)
-                    els.forEach((el) => {
-                      katex.render(el.innerText, el, { displayMode })
-                    })
-                  }
-                  if (postBody) {
-                    renderMath("%s",false);
-                    renderMath("%s",true);
-                  }
-                });
+            <script data-pjax>
+              function renderMath(selector,displayMode) {
+                const els = document.body.querySelectorAll(selector)
+                els.forEach((el) => {
+                  katex.render(el.innerText, el, { displayMode })
+                })
+              }
+              renderMath("%s",false);
+              renderMath("%s",true);
             </script>
             """;
         return String.format(katexScript, inline_selector, display_selector);


### PR DESCRIPTION
To be clear upfront, I still don’t believe plugins should need to accommodate theme pjax functionality, and I continue to have disdain for pjax - it’s fundamentally a flawed technology.

However, we’ve been receiving numerous reports about this plugin not working with pjax, and users have no way of knowing what’s causing the issue, so I’m compromising (for now).


```release-note
兼容部分主题的 Pjax 功能。
```